### PR TITLE
Replace SeededRandom with commons-rng

### DIFF
--- a/zebra-demo/package-lock.json
+++ b/zebra-demo/package-lock.json
@@ -21,7 +21,6 @@
         "@clr/ui": "5.2.0",
         "@webcomponents/webcomponentsjs": "^2.0.0",
         "rxjs": "~6.6.7",
-        "seedrandom": "^3.0.5",
         "tslib": "^2.0.0",
         "zone.js": "~0.10.2"
       },
@@ -14826,11 +14825,6 @@
       "engines": {
         "node": ">= 8.9.0"
       }
-    },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -31701,11 +31695,6 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
-    },
-    "seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/zebra-demo/package.json
+++ b/zebra-demo/package.json
@@ -31,7 +31,6 @@
     "@clr/ui": "5.2.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "rxjs": "~6.6.7",
-    "seedrandom": "^3.0.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
   },

--- a/zebra-demo/src/app/game/game.component.ts
+++ b/zebra-demo/src/app/game/game.component.ts
@@ -4,17 +4,10 @@ const PLAYERS = 4;
 
 declare function main(): void;
 
-// TODO try to fix using https://stackoverflow.com/a/35961176/1551798
-declare var require: any;
-
 declare global {
   interface Window { 
     question: (p: number) => string; 
     zebra4jGenerateQuestionPuzzle: (players: number, seed: string) => string;
-  }
-
-  interface Math {
-    seedrandom: (seed: string) => void;
   }
 }
 
@@ -31,8 +24,6 @@ export class GameComponent implements OnInit {
   completed = false;
 
   constructor() {
-    const seedrandom = require('seedrandom');
-    window.Math.seedrandom = seedrandom;
     main();
     const seed = window.location.hash
     this.currentPuzzle = this.generate(seed);

--- a/zebra-teavm/src/main/java/org/teavm/classlib/java/security/TSecureRandom.java
+++ b/zebra-teavm/src/main/java/org/teavm/classlib/java/security/TSecureRandom.java
@@ -1,0 +1,16 @@
+package org.teavm.classlib.java.security;
+
+import org.teavm.classlib.java.util.TRandom;
+
+/**
+ * A limited implementation of SecureRandom, used by commons-rng
+ * 
+ * <p>
+ * The secure aspect of SecureRandom is not needed in the way we use
+ * commons-rng. Seeding is not supported because commons-rng doesn't use it
+ * either.
+ *
+ */
+public class TSecureRandom extends TRandom {
+
+}

--- a/zebra-teavm/src/main/java/org/teavm/classlib/java/util/concurrent/locks/TReentrantLock.java
+++ b/zebra-teavm/src/main/java/org/teavm/classlib/java/util/concurrent/locks/TReentrantLock.java
@@ -1,0 +1,45 @@
+package org.teavm.classlib.java.util.concurrent.locks;
+
+import org.teavm.classlib.java.lang.TInterruptedException;
+import org.teavm.classlib.java.util.concurrent.TTimeUnit;
+
+/**
+ * Partial implementation of TReentrantLock
+ * 
+ * <p>
+ * TReentrantLock is missing in TeaVM -
+ * https://github.com/konsoletyper/teavm/issues/342 . commons-rng uses it but
+ * the way zebrajs uses commons-rng doesn't require actual locking, so we can
+ * have an empty implementation.
+ * 
+ * <p>
+ * In JDK, ReentrantLock implements Lock but we don't need that either.
+ */
+public class TReentrantLock {
+
+	public TReentrantLock() {
+		this(false);
+	}
+
+	public TReentrantLock(boolean fair) {
+	}
+
+	public void lock() {
+	}
+
+	public void lockInterruptibly() throws TInterruptedException {
+	}
+
+	public boolean tryLock() {
+		return true;
+	}
+
+	public boolean tryLock(long time, TTimeUnit unit) throws InterruptedException {
+		return true;
+	}
+
+	public void unlock() {
+
+	}
+
+}

--- a/zebrajs/pom.xml
+++ b/zebrajs/pom.xml
@@ -97,6 +97,11 @@
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.30</version>
 		</dependency>
+<dependency>
+  <groupId>org.apache.commons</groupId>
+  <artifactId>commons-rng-simple</artifactId>
+  <version>1.3</version>
+</dependency>		
 	</dependencies>
 
 	<build>
@@ -151,7 +156,7 @@
 
 							<!-- Whether TeaVM should produce minified JavaScript. Can reduce 
 								JavaScript file size more than two times -->
-							<minifying>true</minifying>
+							<minifying>false</minifying>
 
 							<!-- Whether TeaVM should produce debug information for its built-in 
 								debugger -->
@@ -165,7 +170,7 @@
 							<sourceFilesCopied>true</sourceFilesCopied>
 
 							<!-- Optimization level. Valid values are: SIMPLE, ADVANCED, FULL -->
-							<optimizationLevel>FULL</optimizationLevel>
+							<optimizationLevel>SIMPLE</optimizationLevel>
 						</configuration>
 					</execution>
 				</executions>

--- a/zebrajs/src/main/java/zebra4j/apps/Client.java
+++ b/zebrajs/src/main/java/zebra4j/apps/Client.java
@@ -40,7 +40,8 @@ public class Client {
 	}
 
 	private static String generatePuzzleWithSeed(int numPeople, String seed) {
-		PuzzleDescription description = generateQuestionPuzzleDescription(numPeople, new SeededRandom(seed), seed);
+		SeededRandom rnd = new SeededRandom(Long.valueOf(seed));
+		PuzzleDescription description = generateQuestionPuzzleDescription(numPeople, rnd, seed);
 		return JSON.serialize(description).stringify();
 	}
 

--- a/zebrajs/src/main/java/zebra4j/apps/SeededRandom.java
+++ b/zebrajs/src/main/java/zebra4j/apps/SeededRandom.java
@@ -2,28 +2,31 @@ package zebra4j.apps;
 
 import java.util.Random;
 
-import org.teavm.jso.JSBody;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.source64.SplitMix64;
 
 /**
- * TeaVM random with seed support based on seedrandom library
+ * TeaVM random with seed support based on commons-rng library
  * 
  * <p>
- * Requires https://github.com/davidbau/seedrandom#readme to be imported.
- *
+ * Similar to {@link org.apache.commons.rng.simple.JDKRandomBridge} but without
+ * all the reflection.
  */
 public class SeededRandom extends Random {
 
 	private static final long serialVersionUID = 1L;
 
+	private transient UniformRandomProvider delegate;
+
 	public SeededRandom(long seed) {
-		seedRandom(String.valueOf(seed));
+		delegate = new SplitMix64(seed);
 	}
 
-	public SeededRandom(String seed) {
-		seedRandom(seed);
+	@Override
+	protected int next(int n) {
+		synchronized (this) {
+			return delegate.nextInt() >>> (32 - n);
+		}
 	}
-
-	@JSBody(params = { "seed" }, script = "Math.seedrandom(seed);")
-	private static native void seedRandom(String seed);
 
 }

--- a/zebrajs/src/main/webapp/index.html
+++ b/zebrajs/src/main/webapp/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>Main page</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="teavm/classes.js"></script>
   </head>
   <body onload="main()">


### PR DESCRIPTION
Replacement of SeededRandom with Random based on commons-rng .

SeededRandom has these issues:
 - it makes zebrajs depend on https://www.npmjs.com/package/seedrandom but it can't import it itself
 - SeededRandom relies on global random seeding which has global effect and
   "should not be done in a production library" quoting https://www.npmjs.com/package/seedrandom .