### PR TITLE
Replace SeededRandom with commons-rng

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<teavm.version>0.7.0-dev-1195</teavm.version>
-		<zebra4j.version>0.8</zebra4j.version>
+		<zebra4j.version>0.9-SNAPSHOT</zebra4j.version>
 	</properties>
 	<build>
 		<pluginManagement><!-- lock down plugins versions to avoid using Maven 

--- a/zebra-demo/package-lock.json
+++ b/zebra-demo/package-lock.json
@@ -21,7 +21,6 @@
         "@clr/ui": "5.2.0",
         "@webcomponents/webcomponentsjs": "^2.0.0",
         "rxjs": "~6.6.7",
-        "seedrandom": "^3.0.5",
         "tslib": "^2.0.0",
         "zone.js": "~0.10.2"
       },
@@ -14826,11 +14825,6 @@
       "engines": {
         "node": ">= 8.9.0"
       }
-    },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -31701,11 +31695,6 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
-    },
-    "seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/zebra-demo/package.json
+++ b/zebra-demo/package.json
@@ -31,7 +31,6 @@
     "@clr/ui": "5.2.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "rxjs": "~6.6.7",
-    "seedrandom": "^3.0.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
   },

--- a/zebra-demo/src/app/game/game.component.ts
+++ b/zebra-demo/src/app/game/game.component.ts
@@ -4,17 +4,10 @@ const PLAYERS = 4;
 
 declare function main(): void;
 
-// TODO try to fix using https://stackoverflow.com/a/35961176/1551798
-declare var require: any;
-
 declare global {
   interface Window { 
     question: (p: number) => string; 
     zebra4jGenerateQuestionPuzzle: (players: number, seed: string) => string;
-  }
-
-  interface Math {
-    seedrandom: (seed: string) => void;
   }
 }
 
@@ -31,8 +24,6 @@ export class GameComponent implements OnInit {
   completed = false;
 
   constructor() {
-    const seedrandom = require('seedrandom');
-    window.Math.seedrandom = seedrandom;
     main();
     const seed = window.location.hash
     this.currentPuzzle = this.generate(seed);

--- a/zebrajs/pom.xml
+++ b/zebrajs/pom.xml
@@ -97,6 +97,16 @@
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.30</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-rng-sampling</artifactId>
+			<version>1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-rng-simple</artifactId>
+			<version>1.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/zebrajs/src/main/java/zebra4j/apps/Client.java
+++ b/zebrajs/src/main/java/zebra4j/apps/Client.java
@@ -1,7 +1,6 @@
 package zebra4j.apps;
 
 import java.util.Locale;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.chocosolver.solver.ChocoSettings;
@@ -16,6 +15,7 @@ import zebra4j.Question;
 import zebra4j.QuestionPuzzle;
 import zebra4j.QuestionPuzzleGenerator;
 import zebra4j.SolutionGenerator;
+import zebra4j.util.Randomness;
 
 public class Client {
 
@@ -40,11 +40,12 @@ public class Client {
 	}
 
 	private static String generatePuzzleWithSeed(int numPeople, String seed) {
-		PuzzleDescription description = generateQuestionPuzzleDescription(numPeople, new SeededRandom(seed), seed);
+		SeededRandom rnd = new SeededRandom(Long.valueOf(seed));
+		PuzzleDescription description = generateQuestionPuzzleDescription(numPeople, rnd, seed);
 		return JSON.serialize(description).stringify();
 	}
 
-	static PuzzleDescription generateQuestionPuzzleDescription(int numPeople, Random rnd, String seed) {
+	static PuzzleDescription generateQuestionPuzzleDescription(int numPeople, Randomness rnd, String seed) {
 		Locale locale = Locale.getDefault();
 		PuzzleSolution sampleSolution = new SolutionGenerator(Attributes.DEFAULT_TYPES, numPeople, rnd).generate();
 		QuestionPuzzleGenerator generator = new QuestionPuzzleGenerator(

--- a/zebrajs/src/main/java/zebra4j/apps/SeededRandom.java
+++ b/zebrajs/src/main/java/zebra4j/apps/SeededRandom.java
@@ -1,29 +1,32 @@
 package zebra4j.apps;
 
-import java.util.Random;
+import java.util.List;
 
-import org.teavm.jso.JSBody;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.source64.SplitMix64;
+import org.apache.commons.rng.sampling.ListSampler;
+
+import zebra4j.util.Randomness;
 
 /**
- * TeaVM random with seed support based on seedrandom library
- * 
- * <p>
- * Requires https://github.com/davidbau/seedrandom#readme to be imported.
- *
+ * {@link Randomness} with seed support based on commons-rng library
  */
-public class SeededRandom extends Random {
+public class SeededRandom implements Randomness {
 
-	private static final long serialVersionUID = 1L;
+	private UniformRandomProvider rnd;
 
 	public SeededRandom(long seed) {
-		seedRandom(String.valueOf(seed));
+		rnd = new SplitMix64(seed);
 	}
 
-	public SeededRandom(String seed) {
-		seedRandom(seed);
+	@Override
+	public void shuffle(List<?> list) {
+		ListSampler.shuffle(rnd, list);
 	}
 
-	@JSBody(params = { "seed" }, script = "Math.seedrandom(seed);")
-	private static native void seedRandom(String seed);
+	@Override
+	public int nextInt(int bound) {
+		return rnd.nextInt(bound);
+	}
 
 }

--- a/zebrajs/src/main/webapp/index.html
+++ b/zebrajs/src/main/webapp/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>Main page</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="teavm/classes.js"></script>
   </head>
   <body onload="main()">

--- a/zebrajs/src/test/java/zebra4j/apps/ClientTest.java
+++ b/zebrajs/src/test/java/zebra4j/apps/ClientTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Random;
 import java.util.Set;
 
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class ClientTest {
 	@Test
 	public void testGenerateQuestionPuzzleDescription() {
 		int numPeople = 3;
-		PuzzleDescription output = Client.generateQuestionPuzzleDescription(numPeople, new Random(), "1");
+		PuzzleDescription output = Client.generateQuestionPuzzleDescription(numPeople, new SeededRandom(1), "1");
 		assertNotNull(output.seed);
 		assertEquals(numPeople, output.answerOptions.size());
 		assertTrue(output.answerOptions.contains(output.answer));

--- a/zebrajs/src/test/java/zebraui/PuzzleGeneratorTest.java
+++ b/zebrajs/src/test/java/zebraui/PuzzleGeneratorTest.java
@@ -28,7 +28,9 @@ public class PuzzleGeneratorTest {
 				AbstractPuzzleGenerator.DEFAULT_FACT_TYPES);
 		puzzleGenerator.setChocoSettings(new ChocoSettings());
 		Puzzle puzzle = puzzleGenerator.generate();
-		Collection<PuzzleSolution> result = new PuzzleSolver(puzzle, new ChocoSettings()).solve();
+		PuzzleSolver solver = new PuzzleSolver(puzzle);
+		solver.setChocoSettings(new ChocoSettings());
+		Collection<PuzzleSolution> result = solver.solve();
 		assertTrue(result.contains(startSolution));
 		assertEquals(1, result.size());
 	}

--- a/zebrajs/src/test/java/zebraui/PuzzleSolverTest.java
+++ b/zebrajs/src/test/java/zebraui/PuzzleSolverTest.java
@@ -12,7 +12,9 @@ public class PuzzleSolverTest extends zebra4j.PuzzleSolverTest {
 
 	@Override
 	protected PuzzleSolver createTestSolver(Puzzle puzzle) {
-		return new PuzzleSolver(puzzle, new ChocoSettings());
+		PuzzleSolver solver = new PuzzleSolver(puzzle);
+		solver.setChocoSettings(new ChocoSettings());
+		return solver;
 	}
 
 }


### PR DESCRIPTION
Replacement of SeededRandom with Randomness based on commons-rng .

SeededRandom has these issues:
 - it makes zebrajs depend on https://www.npmjs.com/package/seedrandom but it can't import it itself
 - SeededRandom relies on global random seeding which has global effect and
   "should not be done in a production library" quoting https://www.npmjs.com/package/seedrandom .